### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
         sudo ufw disable
 
     - name: Test
+      env:
+        CGO_LDFLAGS_ALLOW: "-Wl,-z,now"
       run: |
         go get -tags libsqlite3 github.com/canonical/go-dqlite/app
         go build -tags libsqlite3 -o resources/app resources/app.go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,3 +31,9 @@ jobs:
         sudo ./resources/bridge.sh setup 5
         lein run test --no-ssh --binary $(pwd)/resources/app --workload append --time-limit 180 --nemesis partition,kill,stop --rate 100
         sudo ./resources/bridge.sh teardown 5
+
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: jepsen-data
+        path: store/current

--- a/src/jepsen/dqlite/db.clj
+++ b/src/jepsen/dqlite/db.clj
@@ -263,7 +263,9 @@
       db/LogFiles
       (log-files [_ test node]
         (let [tarball  (str dir "/data.tar.bz2")]
-          (c/exec :tar :cjf tarball data-dir)
+          (try
+            (c/exec :tar :cjf tarball data-dir)
+            (catch Exception e (str "caught exception: " (.getMessage e))))
           [logfile tarball]))
 
       db/Process


### PR DESCRIPTION
- Fix flags for latest go-dqlite master
- tar isn't happy with the changes made in go-dqlite as part of
canonical/go-dqlite#147 , complains that `file changed as we read it` and exits with a non-0 code which causes jepsen to throw an exception when the real test is already done. Because go-dqlite only writes to non-database files I think we can ignore the tar non-0 exit code.