### PR TITLE
actions: Artifact upload doesn't support symbolic link to directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,4 +36,4 @@ jobs:
       if: failure()
       with:
         name: jepsen-data
-        path: store/current
+        path: store/dqlite*


### PR DESCRIPTION
Work around for https://github.com/actions/upload-artifact/issues/92