### PR TITLE
Upgrade to Jepsen 0.2.4 to enable tracing.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         sudo add-apt-repository ppa:dqlite/master -y
         sudo apt update
         sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libraft-dev libdqlite-dev libjna-java graphviz leiningen build-essential
-        sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libjna-java graphviz leiningen build-essential
+        sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libjna-java graphviz leiningen build-essential ntpdate
 
     - name: Build raft
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,13 +33,36 @@ jobs:
         sudo apt update
         sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libraft-dev libdqlite-dev libjna-java graphviz leiningen build-essential
         sudo ufw disable
+        sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libjna-java graphviz leiningen build-essential
+
+    - name: Build raft
+      run: |
+          git clone https://github.com/Canonical/raft.git --depth 1
+          cd raft
+          autoreconf -i
+          ./configure --enable-debug
+          make -j4
+          sudo make install
+          cd ..
+
+    - name: Build dqlite
+      run: |
+          git clone https://github.com/Canonical/dqlite.git --depth 1
+          cd dqlite
+          autoreconf -i
+          ./configure --enable-debug
+          make -j4
+          sudo make install
+          cd ..
 
     - name: Test
       env:
         CGO_LDFLAGS_ALLOW: "-Wl,-z,now"
         LIBRAFT_TRACE: 1
         LIBDQLITE_TRACE: 1
+        LD_LIBRARY_PATH: "/usr/local/lib"
       run: |
+        sudo ldconfig
         go get -tags libsqlite3 github.com/canonical/go-dqlite/app
         go build -tags libsqlite3 -o resources/app resources/app.go
         sudo ./resources/bridge.sh setup 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,6 @@ jobs:
         sudo add-apt-repository ppa:dqlite/master -y
         sudo apt update
         sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libraft-dev libdqlite-dev libjna-java graphviz leiningen build-essential
-        sudo ufw disable
         sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libjna-java graphviz leiningen build-essential
 
     - name: Build raft
@@ -65,6 +64,11 @@ jobs:
         sudo ldconfig
         go get -tags libsqlite3 github.com/canonical/go-dqlite/app
         go build -tags libsqlite3 -o resources/app resources/app.go
+        sudo ufw disable
+        sudo systemctl stop ufw.service
+        sudo systemctl stop systemd-resolved.service
+        sudo sh -c 'echo nameserver 1.1.1.1 >> /etc/resolv.conf'
+        sudo iptables -w -t nat -A POSTROUTING -s 10.2.1.0/24 -d 0.0.0.0/0 -j MASQUERADE
         sudo ./resources/bridge.sh setup 5
         lein run test --no-ssh --binary $(pwd)/resources/app --workload ${{ matrix.workload }} --time-limit 180 --nemesis ${{ matrix.nemesis }} --rate 100
         sudo ./resources/bridge.sh teardown 5

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [jepsen "0.2.1-SNAPSHOT"]
+                 [jepsen "0.2.4-SNAPSHOT"]
                  [clj-http "3.10.1"]]
   :main jepsen.dqlite
   :jvm-opts ["-Djava.awt.headless=true"

--- a/resources/bridge.sh
+++ b/resources/bridge.sh
@@ -22,10 +22,10 @@ n="${2}"
 if [ "${cmd}" = "setup" ]; then
     ip link add name "${BRIDGE}" type bridge
     ip link set "${BRIDGE}" up
-    ip addr add 10.1.1.1/24 brd + dev "${BRIDGE}"
+    ip addr add 10.2.1.1/24 brd + dev "${BRIDGE}"
     for i in $(seq 5); do
-        if ! egrep -qe "^10.1.1.1${i} n${i}" /etc/hosts; then
-            echo "10.1.1.1${i} n${i}" >> /etc/hosts
+        if ! egrep -qe "^10.2.1.1${i} n${i}" /etc/hosts; then
+            echo "10.2.1.1${i} n${i}" >> /etc/hosts
         fi
     done
     exit 0
@@ -34,7 +34,7 @@ fi
 if [ "${cmd}" = "teardown" ]; then
     ip link del "${BRIDGE}"
     for i in $(seq 5); do
-        sed -i "/^10.1.1.1${i} n${i}/d" /etc/hosts
+        sed -i "/^10.2.1.1${i} n${i}/d" /etc/hosts
     done
     exit 0
 fi

--- a/src/jepsen/dqlite/db.clj
+++ b/src/jepsen/dqlite/db.clj
@@ -60,14 +60,20 @@
   "Start the Go dqlite test application"
   [test node]
   (c/exec "mkdir" "-p" data-dir)
-  (cu/start-daemon! {:logfile logfile
-                     :pidfile pidfile
-                     :chdir   data-dir}
-                    binary
-                    :-dir data-dir
-                    :-node (name node)
-                    :-latency (:latency test)
-                    :-cluster (str/join "," (:nodes test))))
+  (letfn [(mkenv [var-name]
+	    (if-let [var-value (System/getenv var-name)]
+	      (str var-name "=" var-value)
+	      nil))]
+    (cu/start-daemon! {:env (c/lit (str/join " " [(mkenv "LIBDQLITE_TRACE") (mkenv "LIBRAFT_TRACE")]))
+                       :logfile logfile
+                       :pidfile pidfile
+                       :chdir   data-dir}
+                      binary
+                      :-dir data-dir
+                      :-node (name node)
+                      :-latency (:latency test)
+                      :-cluster (str/join "," (:nodes test)))))
+
 
 (defn kill!
   "Stop the Go dqlite test application"


### PR DESCRIPTION
- Update Jepsen to 0.2.4 in order to use the new `env` option of `start-daemon!` so that the tracing environment variables are picked up correctly by the dqlite application.
- Build raft & dqlite from source so we're sure it's always latest, greatest.
- The time nemesis that is run by default in 0.2.4 uses `ntpdate`, I had to adapt some networking related settings so that the containers used in the test can perform dns lookups to find the ntp servers. The way I did it might be a bit hacky.