### PR TITLE
app: Don't return err when ErrBusySnapshot

### DIFF
--- a/resources/app.go
+++ b/resources/app.go
@@ -226,7 +226,7 @@ func bankPut(ctx context.Context, db *sql.DB, value string) (string, error) {
 
 	if err != nil {
 		// TODO: retry instead.
-		if err, ok := err.(driver.Error); !ok || err.Code != driver.ErrBusy {
+		if err, ok := err.(driver.Error); !ok || (err.Code != driver.ErrBusy && err.Code != driver.ErrBusySnapshot) {
 			return "", err
 		}
 	}


### PR DESCRIPTION
It means that another transaction is already busy setting up the data
for the test and we can safely back off.

Should eliminate some setup failures in the jepsen bank suite.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>