### PR TITLE
db: Remove pidfile when stopping node

### DIFF
--- a/src/jepsen/dqlite/db.clj
+++ b/src/jepsen/dqlite/db.clj
@@ -75,11 +75,14 @@
 (defn kill!
   "Stop the Go dqlite test application"
   [test node]
+  (info "Killing node")
   (cu/stop-daemon! pidfile))
 
 (defn stop!
   "Stops the Go dqlite test application"
   [test node]
+  (info "Stopping node")
+  (c/exec :rm :-rf pidfile)
   (cu/grepkill! 15 binary))
 
 (defn members


### PR DESCRIPTION
Otherwise start-stop-daemon can start complaining and the node won't be
able to be restarted after stopping it.