### PR TITLE
app: Tweak snapshot parameters

### DIFF
--- a/resources/app.go
+++ b/resources/app.go
@@ -475,7 +475,7 @@ func main() {
 		app.WithLogFunc(dqliteLog),
 		app.WithNetworkLatency(time.Duration(*latency) * time.Millisecond),
 		app.WithRolesAdjustmentFrequency(time.Second),
-		app.WithSnapshotParams(dqlite.SnapshotParams{Threshold: 8, Trailing: 8}),
+		app.WithSnapshotParams(dqlite.SnapshotParams{Threshold: 128, Trailing: 1024}),
 	}
 
 	// When rejoining set app.WithCluster() to the full list of existing


### PR DESCRIPTION
This will hopefully increase the odds of finding a corrupt
segment at startup after killing/stopping node while still being
representative for the default settings in raft. Current test settings
were triggering snapshots a bit too frequently and didn't leave enough
closed segments around.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>