### PR TITLE
db: Prevent wipe function from crashing nemesis.

### DIFF
--- a/src/jepsen/dqlite/db.clj
+++ b/src/jepsen/dqlite/db.clj
@@ -109,8 +109,8 @@
   rejoin it."
   [test node]
   (c/exec :rm :-rf
-          (c/lit (str data-dir "/*"))
-          (c/lit (str data-dir "/.*")))
+          (c/lit (str data-dir)))
+  (c/exec "mkdir" "-p" data-dir)
   (c/exec "touch" (str data-dir "/removed")))
 
 (defn grow!


### PR DESCRIPTION
2022-09-21 22:06:19,003{GMT}    WARN    [jepsen worker nemesis] jepsen.generator.interpreter: Process :nemesis crashed
clojure.lang.ExceptionInfo: Command exited with non-zero status 1 on node n1:
cd /; rm -rf /opt/dqlite/data/* /opt/dqlite/data/.*
STDIN:
null
STDOUT:
STDERR:
rm: refusing to remove '.' or '..' directory: skipping '/opt/dqlite/data/.'
rm: refusing to remove '.' or '..' directory: skipping '/opt/dqlite/data/..'

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>