### PR TITLE
Fix the assertion and core dump checkers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
       run: |
         sudo apt update
         sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libjna-java graphviz leiningen build-essential ntpdate
+        printf '/opt/dqlite/core' | sudo tee /proc/sys/kernel/core_pattern
 
     - name: Build raft
       run: |

--- a/src/jepsen/dqlite/control.clj
+++ b/src/jepsen/dqlite/control.clj
@@ -20,7 +20,8 @@
                 (action :cmd)
                 (if-let [in (:in action)]
                   [:in in]
-                  [])))))
+                  []))
+         (c/throw-on-nonzero-exit))))
 
 (defn cp
   "Copy files."

--- a/src/jepsen/dqlite/db.clj
+++ b/src/jepsen/dqlite/db.clj
@@ -14,8 +14,8 @@
 (def binary (str dir "/" bin))
 (def logfile (str dir "/app.log"))
 (def pidfile (str dir "/app.pid"))
+(def core-dump (str dir "/core"))
 (def data-dir (str dir "/data"))
-(def core-dump (str data-dir "/core"))
 
 (defn setup-ppa!
   "Adds the Dqlite PPA to the APT sources"
@@ -193,35 +193,6 @@
        (remove nil?)
        set))
 
-(def assertion-pattern
-  "An egrep pattern for finding assertion errors in log files."
-  "Assertion|src\\/|raft_start")
-
-(defn logged-assertions
-  "Returns a collection of log lines which look like assertion errors,
-  across all nodes in the test."
-  [test]
-  (let [assertions
-        (->> (c/on-many (:nodes test)
-                        (try+
-                         (c/exec :egrep :-i assertion-pattern logfile)
-                         (catch [:type :jepsen.control/nonzero-exit] _
-                           nil)))
-             (remove (comp nil? val)))]
-    (when (seq assertions)
-      (into {} assertions))))
-
-(defn core-dumps
-  "Returns a collection of nodes on which a core dump of the test
-  application occurred."
-  [test]
-  (let [dumps
-        (->> (c/on-many (:nodes test)
-                        (when (cu/exists? core-dump) "core-dump"))
-             (remove (comp nil? val)))]
-    (when (seq dumps)
-      (into {} dumps))))
-
 (defn db
   "Dqlite test application. Takes a tmpfs DB which is set up prior to setting
   up this DB."
@@ -268,11 +239,12 @@
 
       db/LogFiles
       (log-files [_ test node]
-        (let [tarball  (str dir "/data.tar.bz2")]
+        (let [tarball   (str dir "/data.tar.bz2")
+              core-dump (when (cu/exists? core-dump) core-dump)]
           (try
             (c/exec :tar :cjf tarball data-dir)
             (catch Exception e (str "caught exception: " (.getMessage e))))
-          [logfile tarball]))
+          (remove nil? [logfile core-dump tarball])))
 
       db/Process
       (start! [_ test node]


### PR DESCRIPTION
Our homegrown assertion and core dump checkers were previously trying to access the log and core dump files on the (simulated) remote nodes after those nodes had been torn down, which can't work. The resulting errors were masked by a catch block around the corresponding `jepsen.control/exec` call. I've replaced the assertion checker with `jepsen.checker/log-file-pattern`, which implements just the logic we want; and the core dump checker is rewritten to look for dump files after they've been copied over from the remote nodes.

Signed-off-by: Cole Miller <cole.miller@canonical.com>