### PR TITLE
reduce time limit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
         sudo sh -c 'echo nameserver 1.1.1.1 >> /etc/resolv.conf'
         sudo iptables -w -t nat -A POSTROUTING -s 10.2.1.0/24 -d 0.0.0.0/0 -j MASQUERADE
         sudo ./resources/bridge.sh setup 5
-        lein run test --no-ssh --binary $(pwd)/resources/app --workload ${{ matrix.workload }} --time-limit 240 --nemesis ${{ matrix.nemesis }} --rate 100
+        lein run test --no-ssh --binary $(pwd)/resources/app --workload ${{ matrix.workload }} --time-limit 120 --nemesis ${{ matrix.nemesis }} --rate 100
         sudo ./resources/bridge.sh teardown 5
 
     - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Don't merge, run CI.

Run tests with reduced time.