### PR TITLE
actions: Add timeouts to Job and Test Step.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           - partition,kill,disk
           - partition,kill,member
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -61,6 +62,7 @@ jobs:
       env:
         CGO_LDFLAGS_ALLOW: "-Wl,-z,now"
         LD_LIBRARY_PATH: "/usr/local/lib"
+      timeout-minutes: 8
       run: |
         sudo ldconfig
         go get golang.org/x/sync/semaphore


### PR DESCRIPTION
This will at least fail the jobs instead of letting them sit around for hours. Still debugging cause of hang.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>