### PR TITLE
.github: Remove jobwide timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
           - partition,kill,disk
           - partition,kill,member
     runs-on: ubuntu-20.04
-    timeout-minutes: 15
     steps:
     - name: Checkout code
       uses: actions/checkout@v3


### PR DESCRIPTION
For some reason the job-wide timeout is getting hit, even during the "Setup Environment" step.
Removing timeout and see how it behaves.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>