### PR TITLE
.github: stop systemd.timesyncd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,9 @@ jobs:
         go build -tags libsqlite3 -o resources/app resources/app.go
         sudo ufw disable
         sudo systemctl stop ufw.service
+        # Jepsen tries to stop ntpd itself so that it doesn't interfere with the time.nemesis.
+        # On Ubuntu systemd-timesyncd plays the role of ntpd, so let's stop it.
+        sudo systemctl stop systemd-timesyncd.service
         # Make resolv.conf a real file so we can bind mount it in the namespace
         cp /etc/resolv.conf resolv.conf.tmp
         sudo rm /etc/resolv.conf


### PR DESCRIPTION
This is an attempt to prevent `ntpdate[314]: no server suitable for synchronization found` that is sometimes observed in the tests.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>