### PR TITLE
Add a script for testing locally

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         echo deb http://ddebs.ubuntu.com focal main | sudo tee /etc/apt/sources.list.d/ddebs.list
         sudo apt update
         sudo apt install -y --allow-downgrades gnuplot sqlite3=3.31.1-4 libsqlite3-0=3.31.1-4 libsqlite3-dev=3.31.1-4 libuv1=1.34.2-1ubuntu1 libuv1-dev=1.34.2-1ubuntu1 liblz4-dev libjna-java graphviz leiningen build-essential sqlite3-dbgsym libuv1-dbgsym
-        printf '/opt/dqlite/core' | sudo tee /proc/sys/kernel/core_pattern
+        printf core | sudo tee /proc/sys/kernel/core_pattern
     - name: Install libbacktrace
       run: |
         git clone https://github.com/ianlancetaylor/libbacktrace --depth 1

--- a/src/jepsen/dqlite.clj
+++ b/src/jepsen/dqlite.clj
@@ -39,10 +39,10 @@
             (->> (:nodes test)
                  (pmap (fn [node]
                          (let [{:keys [exit]}
-                               (->> (store/path test node "core")
+                               (->> (store/path test node "app")
                                     .getCanonicalPath
                                     (sh "test" "-e"))]
-                           (when (zero? exit) (str node "/core")))))
+                           (when (zero? exit) node))))
                  (remove nil?))]
 
         {:valid? (empty? blips)

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# Run a Jepsen test locally.
+#
+# Usage:
+#
+# ./test.sh setup
+# ./test.sh run JEPSEN_ARGS
+#
+# `setup` should be run only once to launch and initialize the jepsen container.
+# JEPSEN_ARGS are passed directly to Jepsen (you can omit --no-ssh and --binary).
+# For `./test.sh run`, set the env vars RAFT_BRANCH and DQLITE_BRANCH to control
+# which raft/dqlite are built, e.g. RAFT_BRANCH=mathieu/fix will build the `fix`
+# branch of https://github.com/MathieuBordere/raft.
+
+set -o errexit -o pipefail -o nounset
+
+jepsen=jepsen
+workspace=/root/workspace
+
+push-this-repo() {
+	parent="$(dirname "${BASH_SOURCE[0]}")"
+	lxc file push -p -r "$parent"/* "$jepsen$workspace/jepsen.dqlite"
+}
+
+setup-inner() {
+	echo Set disable_coredump false >>/etc/sudo.conf
+	echo Defaults rlimit_core=infinity >/etc/sudoers.d/99-core
+
+	apt update
+	apt install -y \
+		autoconf \
+		build-essential \
+		git \
+		gnuplot \
+		graphviz \
+		iptables \
+		leiningen \
+		libjna-java \
+		liblz4-dev \
+		libsqlite3-dev \
+		libtool \
+		libuv1-dev \
+		make \
+		pkg-config \
+		snapd
+	snap install go --classic
+
+	pushd "$workspace"
+
+	git clone -o canonical https://github.com/canonical/raft
+	pushd raft
+	git remote add cole https://github.com/cole-miller/raft
+	git remote add mathieu https://github.com/MathieuBordere/raft
+	git remote add mohamed https://github.com/mwnsiri/raft
+	popd
+
+	git clone -o canonical https://github.com/canonical/dqlite
+	pushd dqlite
+	git remote add cole https://github.com/cole-miller/dqlite
+	git remote add mathieu https://github.com/MathieuBordere/dqlite
+	git remote add mohamed https://github.com/mwnsiri/dqlite
+	popd
+
+	popd
+}
+
+setup() {
+	lxc launch images:ubuntu/22.04 jepsen -c limits.kernel.core=-1
+	sleep 5
+	push-this-repo
+	lxc exec "$jepsen" -- "$workspace/jepsen.dqlite/test.sh" setup-inner "$@"
+}
+
+run-inner() {
+	pushd "$workspace"
+
+	pushd raft
+	git fetch --all
+	git checkout "$RAFT_BRANCH"
+	autoreconf -i
+	./configure --enable-debug
+	make -j"$(nproc)"
+	make install
+	popd
+
+	pushd dqlite
+	git fetch --all
+	git checkout "$DQLITE_BRANCH"
+	autoreconf -i
+	./configure --enable-debug
+	make -j"$(nproc)"
+	make install
+	popd
+
+	pushd jepsen.dqlite
+	ip link show jepsen-br >/dev/null 2>&1 || resources/network.sh setup 5
+	go get golang.org/x/sync/semaphore
+	go get -tags libsqlite3 github.com/canonical/go-dqlite/app
+	ldconfig
+	CGO_LDFLAGS_ALLOW='-Wl,-z,now' go build -tags libsqlite3 -o resources/app resources/app.go
+	lein run test --no-ssh --binary "$(pwd)/resources/app" "$@"
+	popd
+
+	popd
+}
+
+run() {
+	test "$(sysctl -n kernel.core_pattern)" = core || exit 1
+	test "$(sysctl -n fs.suid_dumpable)" -gt 0 || exit 1
+	push-this-repo
+	lxc exec $jepsen -- \
+		env RAFT_BRANCH="${RAFT_BRANCH:-canonical/master}" \
+		    DQLITE_BRANCH="${DQLITE_BRANCH:-canonical/master}" \
+		    "$workspace/jepsen.dqlite/test.sh" run-inner "$@"
+}
+
+"$@"


### PR DESCRIPTION
This is finally ready! Please try it out and confirm that it works.

### Prerequisites

I assume that you're running a recent release of Ubuntu.

A couple of things need to be configured on your host machine first. What you want to see:

```
$ sysctl -n fs.suid_dumpable
2
$ sysctl -n kernel.core_pattern
core
```

If you see a different value for the first command, run `sudo sysctl -w fs.suid_dumpable=2`. Note that this has security implications:

<details>

```
suid_dumpable:

This value can be used to query and set the core dump mode for setuid
or otherwise protected/tainted binaries. The modes are

0 - (default) - traditional behaviour. Any process which has changed
privilege levels or is execute only will not be dumped.
1 - (debug) - all processes dump core when possible. The core dump is
owned by the current user and no security is applied. This is
intended for system debugging situations only. Ptrace is unchecked.
This is insecure as it allows regular users to examine the memory
contents of privileged processes.
2 - (suidsafe) - any binary which normally would not be dumped is dumped
anyway, but only if the "core_pattern" kernel sysctl is set to
either a pipe handler or a fully qualified path. (For more details
on this limitation, see CVE-2006-2451.) This mode is appropriate
when administrators are attempting to debug problems in a normal
environment, and either have a core dump pipe handler that knows
to treat privileged core dumps with care, or specific directory
defined for catching core dumps. If a core dump happens without
a pipe handler or fully qualifid path, a message will be emitted
to syslog warning about the lack of a correct setting.
```
</details>

If the output of the second command is something like `|apport`, disable [apport](https://wiki.ubuntu.com/Apport) with `systemctl disable apport`; if it's something like `|systemd-coredump`, do `sudo apt remove systemd-coredump`.

### Usage

Run `./test.sh setup` just once to initialize the container. After that, when you want to run a Jepsen test, do `./test.sh run ARGS...`; `ARGS` are passed to the Jepsen invocation, e.g. `./test.sh run --workload append --nemesis kill`.

By default, raft and dqlite will be built from the master branch of the canonical GitHub repo. `./test.sh run` recognizes the environment variables `RAFT_BRANCH` and `DQLITE_BRANCH` to allow selecting a different source, e.g. `RAFT_BRANCH=mathieu/fix` will build from the `fix` branch of https://github.com/MathieuBordere/raft.

Any changes to files in this repo will be pushed into the container when you do `./test.sh run`.

After running a test, you can do `lxc exec jepsen bash` and `cd /root/workspace/jepsen.dqlite/store/latest`, where the Jepsen log and uploaded files from each node are stored (core dumps are in `data.tar.bz2`).

Closes #38 

Signed-off-by: Cole Miller <cole.miller@canonical.com>