### PR TITLE
Replace all (op :f) by (:f op)

### DIFF
--- a/src/jepsen/dqlite/client.clj
+++ b/src/jepsen/dqlite/client.clj
@@ -93,7 +93,7 @@
          (catch [:msg "Error: failed to create dqlite connection: no available dqlite leader server found"] e#
            (assoc ~op :type :fail, :error :unavailable))
          (catch [:msg "Error: driver: bad connection"] e#
-           (assoc ~op :type (if (= (~op :f) :read) :fail :info), :error :bad-connection))
+           (assoc ~op :type (if (= (:f ~op) :read) :fail :info), :error :bad-connection))
          (catch (and (:msg ~'%)
                      (re-find #"receive: header: EOF" (:msg ~'%)))
            e#
@@ -101,9 +101,9 @@
          (catch [:type ::no-seriously-timeout] e#
            (assoc ~op :type :info, :error :no-seriously-timeout))
          (catch SocketTimeoutException e#
-           (assoc ~op :type (if (= (~op :f) :read) :fail :info), :error :connection-timeout))
+           (assoc ~op :type (if (= (:f ~op) :read) :fail :info), :error :connection-timeout))
          (catch SocketException e#
-           (assoc ~op :type (if (= (~op :f) :read) :fail :info), :error :connection-error))
+           (assoc ~op :type (if (= (:f ~op) :read) :fail :info), :error :connection-error))
          (catch ConnectException e#
            (assoc ~op :type :fail, :error :connection-refused))
          (catch org.apache.http.NoHttpResponseException e#


### PR DESCRIPTION
The former no longer works with Jepsen v0.3.0.

Signed-off-by: Cole Miller <cole.miller@canonical.com>