### PR TITLE
Put the clock nemesis back

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         sudo apt install ubuntu-dbgsym-keyring
         echo deb http://ddebs.ubuntu.com focal main | sudo tee /etc/apt/sources.list.d/ddebs.list
         sudo apt update
-        sudo apt install -y --allow-downgrades gnuplot sqlite3=3.31.1-4 libsqlite3-0=3.31.1-4 libsqlite3-dev=3.31.1-4 libuv1=1.34.2-1ubuntu1 libuv1-dev=1.34.2-1ubuntu1 liblz4-dev libjna-java graphviz leiningen build-essential sqlite3-dbgsym libuv1-dbgsym
+        sudo apt install -y --allow-downgrades gnuplot sqlite3=3.31.1-4 libsqlite3-0=3.31.1-4 libsqlite3-dev=3.31.1-4 libuv1=1.34.2-1ubuntu1 libuv1-dev=1.34.2-1ubuntu1 liblz4-dev libjna-java graphviz leiningen build-essential ntpdate sqlite3-dbgsym libuv1-dbgsym
         printf core | sudo tee /proc/sys/kernel/core_pattern
     - name: Install libbacktrace
       run: |
@@ -84,6 +84,14 @@ jobs:
         go build -tags libsqlite3 -o resources/app resources/app.go
         sudo ufw disable
         sudo systemctl stop ufw.service
+        # Jepsen tries to stop ntpd itself so that it doesn't interfere with the time.nemesis.
+        # On Ubuntu systemd-timesyncd plays the role of ntpd, so let's stop it.
+        sudo systemctl stop systemd-timesyncd.service
+        # Make resolv.conf a real file so we can bind mount it in the namespace
+        cp /etc/resolv.conf resolv.conf.tmp
+        sudo rm /etc/resolv.conf
+        sudo mv resolv.conf.tmp /etc/resolv.conf
+        sudo iptables -w -t nat -A POSTROUTING -s 10.2.1.0/24 -d 0.0.0.0/0 -j MASQUERADE
         sudo ./resources/network.sh setup 5
         if test ${{ matrix.workload }} = set && test ${{ matrix.nemesis }} = stop; then echo 120 >time-limit; else echo 240 >time-limit; fi
         lein run test --no-ssh --binary $(pwd)/resources/app --workload ${{ matrix.workload }} --time-limit $(cat time-limit) --nemesis ${{ matrix.nemesis }} --rate 100

--- a/resources/network.sh
+++ b/resources/network.sh
@@ -1,9 +1,11 @@
 #!/bin/sh -e
 
 BRIDGE="jepsen-br"
+FILE="/etc/resolv.conf.jepsen"
 
 help() {
     echo "Set up and tear down network resources for inter-node communication."
+    echo "This will create a bridge and a resolv.conf file"
     echo
     echo "Usage:"
     echo
@@ -28,6 +30,12 @@ if [ "${cmd}" = "setup" ]; then
             echo "10.2.1.1${i} n${i}" >> /etc/hosts
         fi
     done
+
+    if [ ! -f "$FILE" ]; then
+        echo nameserver 8.8.8.8 >> $FILE
+        echo nameserver 8.8.4.4 >> $FILE
+    fi
+
     exit 0
 fi
 

--- a/src/jepsen/dqlite/nemesis.clj
+++ b/src/jepsen/dqlite/nemesis.clj
@@ -109,11 +109,10 @@
   "Constructs a nemesis and generators for dqlite."
   [opts]
   (let [opts (update opts :faults set)]
-    (->> (concat [(nc/partition-package opts)
-                  (nc/db-package opts)
-                  (member-package opts)
-                  (stop-package opts)
-                  (stable-package opts)]
+    (-> (nc/nemesis-packages opts)
+        (concat [(member-package opts)
+                 (stop-package opts)
+                 (stable-package opts)]
                 (:extra-packages opts))
-        (remove nil?)
+        (->> (remove nil?))
         nc/compose-packages)))

--- a/src/jepsen/dqlite/nemesis.clj
+++ b/src/jepsen/dqlite/nemesis.clj
@@ -109,7 +109,9 @@
   "Constructs a nemesis and generators for dqlite."
   [opts]
   (let [opts (update opts :faults set)]
-    (-> (nc/nemesis-packages opts)
+    (-> [(nc/partition-package opts)
+         (nc/clock-package opts)
+         (nc/db-package opts)]
         (concat [(member-package opts)
                  (stop-package opts)
                  (stable-package opts)]

--- a/src/jepsen/os/container.clj
+++ b/src/jepsen/os/container.clj
@@ -62,6 +62,9 @@
         (exec :sudo :ip :link :set veth2 :up)
         (exec :sudo :ip :link :set veth2 :master bridge)
 
+        ;; Set up /etc/resolv.conf
+        (exec :sudo :nsenter :-p :-n :-m :-t pid :mount :--bind "/etc/resolv.conf.jepsen" "/etc/resolv.conf")
+
         ;; Set up /opt
         (exec :sudo :mkdir :-p node-dir)
         (exec :sudo :nsenter :-p :-n :-m :-t pid :mount :--bind node-dir "/opt"))


### PR DESCRIPTION
It seems that #62 made Jepsen less effective at finding crashes in raft/dqlite -- which is unexpected, since the clock nemesis shouldn't even work inside `nsenter`! Let's restore it until we figure out what's going on.

This reverts commit 281f8b4d65e16c2d6357edaf438c116c8794cb3c.

Signed-off-by: Cole Miller <cole.miller@canonical.com>