### PR TITLE
dqlite: Sleep before healing cluster

### DIFF
--- a/src/jepsen/dqlite.clj
+++ b/src/jepsen/dqlite.clj
@@ -99,6 +99,8 @@
                                            {:type :info, :f :stable, :value nil}
                                            (:generator nemesis)))
                              (gen/time-limit (:time-limit opts)))
+                        ;; Allow dust to settle before healing cluster
+                        (gen/sleep 3)
                         (gen/log "Healing cluster")
                         (gen/nemesis (:final-generator nemesis))
                         (gen/log "Waiting for recovery")


### PR DESCRIPTION
This should e.g. allow nodes that were asked to stop just before healing the cluster to stop properly.

Signed-off-by: Mathieu Borderé <mathieu.bordere@canonical.com>

(should) fix #74 