### PR TITLE
Don't try to install debug symbols

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,8 @@ jobs:
 
     - name: Setup environment
       run: |
-        sudo apt install ubuntu-dbgsym-keyring
-        echo deb http://ddebs.ubuntu.com focal main | sudo tee /etc/apt/sources.list.d/ddebs.list
         sudo apt update
-        sudo apt install -y --allow-downgrades gnuplot sqlite3=3.31.1-4 libsqlite3-0=3.31.1-4 libsqlite3-dev=3.31.1-4 libuv1=1.34.2-1ubuntu1 libuv1-dev=1.34.2-1ubuntu1 liblz4-dev libjna-java graphviz leiningen build-essential sqlite3-dbgsym libuv1-dbgsym
+        sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libjna-java graphviz leiningen build-essential
         printf core | sudo tee /proc/sys/kernel/core_pattern
     - name: Install libbacktrace
       run: |


### PR DESCRIPTION
CI is regularly failing due to HTTP 503 errors from ddebs.ubuntu.com, which  makes it too easy to miss failures that we care about. Abandon our attempt to install debug symbols from that server for now (we'll still have debug symbols for libraft and libdqlite, which hopefully is enough to make backtraces useful).

Signed-off-by: Cole Miller <cole.miller@canonical.com>