### PR TITLE
GitHub action: enable manually triggering test runs with arbitrary test/raft/dqlite repositories/branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,28 @@
 name: Dqlite Jepsen tests
+
 on:
-    push:
-    pull_request:
-    schedule:
-      - cron: "0 */1 * * *"
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 */1 * * *"
+  workflow_dispatch:
+    inputs:
+      raftRepo:
+        description: 'Raft Repo'
+        required: true
+        default: 'https://github.com/Canonical/raft.git'
+      raftBranch:
+        description: 'Raft Branch'
+        required: true
+        default: 'master'
+      dqliteRepo:
+        description: 'Dqlite Repo'
+        required: true
+        default: 'https://github.com/Canonical/dqlite.git'
+      dqliteBranch:
+        description: 'Dqlite Branch'
+        required: true
+        default: 'master'
 
 jobs:
   test:
@@ -37,6 +56,7 @@ jobs:
         sudo apt update
         sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libjna-java graphviz leiningen build-essential
         printf core | sudo tee /proc/sys/kernel/core_pattern
+
     - name: Install libbacktrace
       run: |
         git clone https://github.com/ianlancetaylor/libbacktrace --depth 1
@@ -49,8 +69,11 @@ jobs:
         cd ..
 
     - name: Build raft
+      env:
+        RAFT_REPO: 'https://github.com/Canonical/raft.git'
+        RAFT_BRANCH: 'master'
       run: |
-          git clone https://github.com/Canonical/raft.git --depth 1
+          git clone --branch ${{ inputs.raftBranch || env.RAFT_BRANCH }} --single-branch --depth 1 ${{ inputs.raftRepo || env.RAFT_REPO }}
           cd raft
           git log -n 1
           autoreconf -i
@@ -60,8 +83,11 @@ jobs:
           cd ..
 
     - name: Build dqlite
+      env:
+        DQLITE_REPO: 'https://github.com/Canonical/dqlite.git'
+        DQLITE_BRANCH: 'master'
       run: |
-          git clone https://github.com/Canonical/dqlite.git --depth 1
+          git clone --branch ${{ inputs.dqliteBranch || env.DQLITE_BRANCH }} --single-branch --depth 1 ${{ inputs.dqliteRepo || env.DQLITE_REPO }}
           cd dqlite
           git log -n 1
           autoreconf -i

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         RAFT_REPO: 'https://github.com/Canonical/raft.git'
         RAFT_BRANCH: 'master'
       run: |
-          git clone --branch ${{ inputs.raftBranch || env.RAFT_BRANCH }} --single-branch --depth 1 ${{ inputs.raftRepo || env.RAFT_REPO }}
+          git clone --branch ${{ inputs.raftBranch || env.RAFT_BRANCH }} --depth 1 ${{ inputs.raftRepo || env.RAFT_REPO }}
           cd raft
           git log -n 1
           autoreconf -i
@@ -87,7 +87,7 @@ jobs:
         DQLITE_REPO: 'https://github.com/Canonical/dqlite.git'
         DQLITE_BRANCH: 'master'
       run: |
-          git clone --branch ${{ inputs.dqliteBranch || env.DQLITE_BRANCH }} --single-branch --depth 1 ${{ inputs.dqliteRepo || env.DQLITE_REPO }}
+          git clone --branch ${{ inputs.dqliteBranch || env.DQLITE_BRANCH }} --depth 1 ${{ inputs.dqliteRepo || env.DQLITE_REPO }}
           cd dqlite
           git log -n 1
           autoreconf -i


### PR DESCRIPTION
Hi,

This PR adds the ability to manually trigger test runs with arbitrary test/raft/dqlite repositories/branches.

No more submitting fake PRs to trigger a test run!

It adds an `on workflow_dispatch` to the action.
This will add a `Run Workflow` button to Actions -> Dqlite Jepsen tests:

![manually trigger action](https://user-images.githubusercontent.com/86082495/223267050-87275e1a-81da-417f-a1b4-508695c76733.png)
