### PR TITLE
Update set, bank tests

### DIFF
--- a/src/jepsen/dqlite.clj
+++ b/src/jepsen/dqlite.clj
@@ -8,7 +8,8 @@
                     [cli :as cli]
                     [generator :as gen]
                     [store :as store]
-                    [tests :as tests]]
+                    [tests :as tests]
+                    [util :as u]]
             [jepsen.os.ubuntu :as ubuntu]
             [jepsen.os.container :as container]
             [jepsen.dqlite [db :as db]
@@ -48,6 +49,23 @@
          :count (count blips)
          :blips blips}))))
 
+(defn test-name
+  "Human friendly test name."
+  [{:keys [workload nemesis nodes concurrency rate] :as _opts}]
+  (let [workload (name workload)
+        nemesis  (if nemesis
+                   (u/coll nemesis)
+                   [:no-faults])
+        nemesis  (->> nemesis
+                      (map name)
+                      (str/join "-"))
+        num-nodes (count nodes)]
+    (str "dqlite"
+         "-" workload
+         "-" nemesis
+         "-" num-nodes "n" concurrency "c"
+         "-" rate "ops")))
+
 (defn test
   "Constructs a test from a map of CLI options."
   [opts]
@@ -73,7 +91,7 @@
     (merge tests/noop-test
            opts
            bank/options
-           {:name      (str "dqlite-" (name workload-name))
+           {:name      (test-name opts)
             :pure-generators true
             :members   (atom (into (sorted-set) (:nodes opts)))
             :local     local

--- a/src/jepsen/dqlite/nemesis.clj
+++ b/src/jepsen/dqlite/nemesis.clj
@@ -103,7 +103,13 @@
 (defn stable-package
   [opts]
   {:nemesis (stable-nemesis opts)
-   :generator nil})
+   :generator nil
+   :perf #{{:name  "stable"
+            :fs    [:stable]
+            :color "#90EEA8"}
+           {:name  "health"
+            :fs    [:health]
+            :color "#90EE90"}}})
 
 (defn nemesis-package
   "Constructs a nemesis and generators for dqlite."


### PR DESCRIPTION
Set test:

- update generator for better coverage
  - from exclusively doing reads on n1,2,3 and writes on n4,5
  - to a random mix of reads and writes across all nodes

- final generator for final reads

- config checker for `{:linearizable? true}`
  - explicitly confirm no stale reads

Bank test:

- final generator for final reads

- update options
  -  greater max transfer amount gives slightly better unique values
  -  0 totals are easier to read in the logs

Final read on each node after healing/sleep to confirm available/consistent:
- tests can end
  - with unread writes 
    - due to random transaction ordering
    - active nemesis that prevented reads
  - in complex states that change with healing

Human friendly title for plots and filenames.

Label/color stable/health checks on plots.