### PR TITLE
Increase diversity of partition types

### DIFF
--- a/src/jepsen/dqlite.clj
+++ b/src/jepsen/dqlite.clj
@@ -26,6 +26,10 @@
    :bank   bank/workload
    :set    set/workload})
 
+(def all-partition-specs
+  "All partition specifications supported by test."
+  #{:primaries :one :majority :majorities-ring}) ; :minority-third usually redundant
+
 (def assertion-pattern
   "An egrep pattern for finding assertion errors in log files."
   "Assertion|raft_start|start-stop-daemon|for jepsen")
@@ -55,7 +59,7 @@
         workload      ((get workloads (:workload opts)) opts)
         nemesis-opts  {:faults (set (:nemesis opts))
                        :nodes  (:nodes opts)
-                       :partition {:targets [:primaries]}
+                       :partition {:targets (:partition-targets opts)}
                        :pause     {:targets [nil :one :primaries :majority :all]}
                        :kill      {:targets [nil :one :primaries :majority :all]}
                        :interval  (:nemesis-interval opts)
@@ -125,6 +129,13 @@
        (map keyword)
        (mapcat #(get special-nemeses % [%]))))
 
+(defn parse-comma-kws
+  "Takes a comma-separated string and returns a collection of keywords."
+  [spec]
+  (->> (str/split spec #",")
+       (remove #{""})
+       (map keyword)))
+
 (def cli-opts
   "Command line options for tools.cli"
   [["-v" "--version VERSION" "What version of Dqlite should to install"
@@ -141,6 +152,12 @@
     :parse-fn parse-long
     :validate [pos? "Must be a positive number."]]
 
+   [nil "--partition-targets TARGETS" (str "A comma-separated list of nodes to target for network partitions; "
+                                           (cli/one-of all-partition-specs))
+    :default  (vec all-partition-specs)
+    :parse-fn parse-comma-kws
+    :validate [(partial every? all-partition-specs) (cli/one-of all-partition-specs)]]
+   
    [nil "--latency MSECS" "Expected average one-way network latency between nodes."
     :default 10
     :parse-fn parse-long

--- a/src/jepsen/dqlite.clj
+++ b/src/jepsen/dqlite.clj
@@ -152,7 +152,7 @@
     :parse-fn parse-long
     :validate [pos? "Must be a positive number."]]
 
-   [nil "--partition-targets TARGETS" (str "A comma-separated list of nodes to target for network partitions; "
+   [nil "--partition-targets TARGETS" (str "A comma-separated list of partition strategies to use for network partitions; "
                                            (cli/one-of all-partition-specs))
     :default  (vec all-partition-specs)
     :parse-fn parse-comma-kws


### PR DESCRIPTION
This PR increases the diversity of partition types and makes it configurable.

Partition targeting strategies are changed:
- from `[:primaries]`
- to `[:primaries :one :majority :majorities-ring]`

And made configurable with `--partition-targets`.

This is a common Jepsen pattern.


`:primaries` partitions the cluster:
- leader's node (1 node minority)
- all other nodes (4 (usually) node majority)

Targeting the leader is a juicy target.
But it doesn't cover going into and recovering from all of the other leader/member majority/minority possibilities and how they combine with other faults.

----

`:majorities-ring` partitions so every node can see a majority, but no node sees the *same* majority as any other.
The raft implementation remained resilient:
- kept same leader
- many, but not all, transactions ok
- prompt healing

```
jepsen.dqlite.db: Primary cache now #{n1}
...
:nemesis	:info	:start-partition	:majorities-ring
:nemesis	:info	:start-partition	[:isolated {"n2" #{"n5" "n1"}, "n4" #{"n1" "n3"}, "n5" #{"n2" "n3"}, "n1" #{"n2" "n4"}, "n3" #{"n5" "n4"}}]
...
jepsen.dqlite.db: Primary cache now #{n1}
```

![majorities ring latency](https://user-images.githubusercontent.com/86082495/224457897-be27326b-2d93-444a-9107-b85015470b91.png)

