### PR TITLE
Upgrade to latest Jepsen, dev env housekeeping

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,9 +69,10 @@ jobs:
           - disk
           - member
           - partition,kill,stop
-          - partition,kill,disk
+          - partition,kill
           - partition,kill,member
-          - partition,pause,disk
+          - partition,disk
+          - pause,disk
     runs-on: ubuntu-20.04
     timeout-minutes: 25
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,20 +9,48 @@ on:
     inputs:
       raftRepo:
         description: 'Raft Repo'
-        required: true
         default: 'https://github.com/Canonical/raft.git'
       raftBranch:
         description: 'Raft Branch'
-        required: true
         default: 'master'
       dqliteRepo:
         description: 'Dqlite Repo'
-        required: true
         default: 'https://github.com/Canonical/dqlite.git'
       dqliteBranch:
         description: 'Dqlite Branch'
-        required: true
         default: 'master'
+  workflow_call:
+    inputs:
+      jepsenDqliteRepo:
+        type: string
+        required: false
+      jepsenDqliteBranch:
+        type: string
+        required: false
+      jepsenRepo:
+        type: string
+        required: false
+      jepsenBranch:
+        type: string
+        required: false
+      raftRepo:
+        type: string
+        required: false
+      raftBranch:
+        type: string
+        required: false
+      dqliteRepo:
+        type: string
+        required: false
+      dqliteBranch:
+        type: string
+        required: false
+
+env:
+  RAFT_REPO:   'https://github.com/Canonical/raft.git'
+  RAFT_BRANCH: 'master'
+  DQLITE_REPO:   'https://github.com/Canonical/dqlite.git'
+  DQLITE_BRANCH: 'master'
 
 jobs:
   test:
@@ -47,6 +75,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+      with:
+        repository: ${{ inputs.jepsenDqliteRepo || github.repository }}
+        ref: ${{ inputs.jepsenDqliteBranch || github.ref }}
 
     - name: Cache Go modules
       uses: actions/cache@v3
@@ -76,6 +107,15 @@ jobs:
         sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libjna-java graphviz leiningen build-essential
         printf core | sudo tee /proc/sys/kernel/core_pattern
 
+    - name: Install local Jepsen
+      if: ${{ inputs.jepsenRepo && inputs.jepsenBranch }}
+      run: |
+        git clone --branch ${{ inputs.jepsenBranch }} --depth 1 ${{ inputs.jepsenRepo }}
+        cd jepsen/jepsen
+        git log -n 1
+        lein install
+        cd ../..
+
     - name: Install libbacktrace
       run: |
         git clone https://github.com/ianlancetaylor/libbacktrace --depth 1
@@ -88,9 +128,6 @@ jobs:
         cd ..
 
     - name: Build raft
-      env:
-        RAFT_REPO: 'https://github.com/Canonical/raft.git'
-        RAFT_BRANCH: 'master'
       run: |
           git clone --branch ${{ inputs.raftBranch || env.RAFT_BRANCH }} --depth 1 ${{ inputs.raftRepo || env.RAFT_REPO }}
           cd raft
@@ -102,9 +139,6 @@ jobs:
           cd ..
 
     - name: Build dqlite
-      env:
-        DQLITE_REPO: 'https://github.com/Canonical/dqlite.git'
-        DQLITE_BRANCH: 'master'
       run: |
           git clone --branch ${{ inputs.dqliteBranch || env.DQLITE_BRANCH }} --depth 1 ${{ inputs.dqliteRepo || env.DQLITE_REPO }}
           cd dqlite
@@ -126,14 +160,35 @@ jobs:
         go get -tags libsqlite3 github.com/canonical/go-dqlite/app
         go build -tags libsqlite3 -o resources/app resources/app.go
         sudo ufw disable
+        sleep 0.200
         sudo systemctl stop ufw.service
         sudo ./resources/network.sh setup 5
         if test ${{ matrix.workload }} = set && test ${{ matrix.nemesis }} = stop; then echo 120 >time-limit; else echo 240 >time-limit; fi
         lein run test --no-ssh --binary $(pwd)/resources/app --workload ${{ matrix.workload }} --time-limit $(cat time-limit) --nemesis ${{ matrix.nemesis }} --rate 100
         sudo ./resources/network.sh teardown 5
 
-    - uses: actions/upload-artifact@v3
-      if: failure()
+    - name: Jepsen log Summary
+      if: ${{ always() }}
+      run: tail -n 100 store/current/jepsen.log > tail-jepsen.log
+
+    - name: Summary Artifact
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
       with:
-        name: jepsen-data-${{ matrix.workload }}-${{ matrix.nemesis }}
-        path: store/dqlite*
+        name: jepsen-data-${{ matrix.workload }}-${{ matrix.nemesis }}-summary
+        path: |
+          tail-jepsen.log
+          store/dqlite*/**/results.edn
+          store/dqlite*/**/latency-raw.png
+          !**/current/
+          !**/latest/
+
+    - name: Failure Artifact
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: jepsen-data-${{ matrix.workload }}-${{ matrix.nemesis }}-failure
+        path: |
+          store/dqlite*
+          !**/current/
+          !**/latest/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,11 +65,13 @@ jobs:
           - partition
           - kill
           - stop
+          - pause
           - disk
           - member
           - partition,kill,stop
           - partition,kill,disk
           - partition,kill,member
+          - partition,pause,disk
     runs-on: ubuntu-20.04
     timeout-minutes: 25
     steps:
@@ -169,7 +171,7 @@ jobs:
 
     - name: Jepsen log Summary
       if: ${{ always() }}
-      run: tail -n 100 store/current/jepsen.log > tail-jepsen.log
+      run: tail -n 100 store/current/jepsen.log > store/current/tail-jepsen.log
 
     - name: Summary Artifact
       if: ${{ always() }}
@@ -177,9 +179,9 @@ jobs:
       with:
         name: jepsen-data-${{ matrix.workload }}-${{ matrix.nemesis }}-summary
         path: |
-          tail-jepsen.log
           store/dqlite*/**/results.edn
           store/dqlite*/**/latency-raw.png
+          store/dqlite*/**/tail-jepsen.log
           !**/current/
           !**/latest/
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,9 +68,9 @@ jobs:
           - pause
           - disk
           - member
-          - partition,kill,stop
+          - partition,stop
           - partition,kill
-          - partition,kill,member
+          - partition,member
           - partition,disk
           - pause,disk
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ pom.xml.asc
 .hg/
 store/
 resources/app
+.calva/
+.clj-kondo/
+.lsp/

--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [jepsen "0.3.2-SNAPSHOT"]
+                 [jepsen "0.3.2-SNAPSHOT"]
                  [clj-http "3.10.1"]]
   :main jepsen.dqlite
   :jvm-opts ["-Djava.awt.headless=true"

--- a/project.clj
+++ b/project.clj
@@ -12,4 +12,9 @@
              ;"-XX:+PrintGCDetails"
              ;"-verbose:gc"
              ]
-  :repl-options {:init-ns jepsen.dqlite})
+  :repl-options {:init-ns jepsen.dqlite}
+  :plugins [[lein-codox "0.10.8"]
+            [lein-localrepo "0.5.4"]]
+  :codox {:output-path "target/doc/"
+          :source-uri "../../{filepath}#L{line}"
+          :metadata {:doc/format :markdown}})

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [jepsen "0.2.6"]
+                 [jepsen "0.3.2-SNAPSHOT"]
                  [clj-http "3.10.1"]]
   :main jepsen.dqlite
   :jvm-opts ["-Djava.awt.headless=true"

--- a/src/jepsen/dqlite.clj
+++ b/src/jepsen/dqlite.clj
@@ -80,7 +80,8 @@
                        :pause     {:targets [nil :one :primaries :majority :all]}
                        :kill      {:targets [nil :one :primaries :majority :all]}
                        :interval  (:nemesis-interval opts)
-                       :disk      {:dir     db/data-dir
+                       :disk      {:targets [nil :one :primaries :majority :all]
+                                   :dir     db/data-dir
                                    :size-mb 100}}
         local         (:dummy? (:ssh opts))
         os            (if local container/os ubuntu/os)

--- a/src/jepsen/dqlite/append.clj
+++ b/src/jepsen/dqlite/append.clj
@@ -1,7 +1,6 @@
 (ns jepsen.dqlite.append
   "Test for transactional list append."
-  (:require [clojure [string :as str]]
-            [jepsen [client :as client]]
+  (:require [jepsen [client :as client]]
             [jepsen.tests.cycle.append :as append]
             [jepsen.dqlite [client :as c]]))
 
@@ -27,9 +26,11 @@
 
 (defn workload
   "A list append workload."
-  [opts]
-  (assoc (append/test {:key-count         10
-                       :max-txn-length    2
+  [{:keys [key-count min-txn-length max-txn-length max-writes-per-key] :as _opts}]
+  (merge (append/test {:key-count          (or key-count 12)
+                       :min-txn-length     (or min-txn-length 1)
+                       :max-txn-length     (or max-txn-length 4)
+                       :max-writes-per-key (or max-writes-per-key 128)
                        :consistency-models [:serializable
                                             :strict-serializable]})
-         :client (Client. nil)))
+         {:client (Client. nil)}))

--- a/src/jepsen/dqlite/bank.clj
+++ b/src/jepsen/dqlite/bank.clj
@@ -41,6 +41,7 @@
   "A bank workload."
   [_opts]
   (merge (bank/test {:negative-balances? true})
+         options
          {:client (Client. nil)
           :final-generator (gen/phases
                             (gen/log "Final reads...")

--- a/src/jepsen/dqlite/db.clj
+++ b/src/jepsen/dqlite/db.clj
@@ -248,6 +248,7 @@
         (kill! test node)
         (when tmpfs
           (db/teardown! tmpfs test node))
+        (Thread/sleep 200) ; avoid race: rm: cannot remove '/opt/dqlite/data': Directory not empty
         (c/su (c/exec :rm :-rf dir)))
 
       db/LogFiles
@@ -275,8 +276,17 @@
         (kill! test node))
 
       db/Pause
-      (pause!  [_ test node] (c/su (cu/grepkill! :stop "app")))
-      (resume! [_ test node] (c/su (cu/grepkill! :cont "app")))
+      (pause!
+        [_db _test _node]
+        (c/su
+         (cu/grepkill! :stop bin))
+        :paused)
+
+      (resume!
+        [_db _test _node]
+        (c/su
+         (cu/grepkill! :cont bin))
+        :resumed)
 
       db/Primary
       (setup-primary! [db test node])

--- a/src/jepsen/dqlite/db.clj
+++ b/src/jepsen/dqlite/db.clj
@@ -57,35 +57,40 @@
 (defn start!
   "Start the Go dqlite test application"
   [test node]
-  (info "Starting node")
-  (c/exec "mkdir" "-p" data-dir)
-  ;; XXX this is a workaround, it seems that the pidfile gets the wrong
-  ;; permissions somehow
-  (when (cu/exists? pidfile)
-    (c/exec "chmod" "go-w" pidfile))
-  (cu/start-daemon! {:env {:LIBDQLITE_TRACE "1"
-                           :LIBRAFT_TRACE "1"}
-                     :logfile logfile
-                     :pidfile pidfile
-                     :chdir   data-dir}
-                    binary
-                    :-dir data-dir
-                    :-node (name node)
-                    :-latency (:latency test)
-                    :-cluster (str/join "," (:nodes test))))
+  (if (cu/daemon-running? pidfile)
+    :already-running
+    (c/su
+      (c/exec :mkdir :-p data-dir)
+      (cu/start-daemon! {:env {:LIBDQLITE_TRACE "1"
+                               :LIBRAFT_TRACE "1"}
+                         :logfile logfile
+                         :pidfile pidfile
+                         :chdir   data-dir}
+                        binary
+                        :-dir data-dir
+                        :-node (name node)
+                        :-latency (:latency test)
+                        :-cluster (str/join "," (:nodes test))))))
 
 (defn kill!
-  "Stop the Go dqlite test application"
-  [test node]
-  (info "Killing node")
-  (cu/stop-daemon! pidfile))
+  "Gracefully kill, `SIGTERM`, the Go dqlite test application."
+  [_test node]
+  (let [signal :SIGTERM]
+    (info "Killing" bin "with" signal "on" node)
+    (c/su
+     (cu/grepkill! signal bin))
+    :killed))
 
 (defn stop!
-  "Stops the Go dqlite test application"
-  [test node]
-  (info "Stopping node")
-  (c/exec :rm :-f pidfile)
-  (cu/grepkill! 15 binary))
+  "Stop the Go dqlite test application with `stop-daemon!`,
+   which will `SIGKILL`."
+  [_test _node]
+  (if (not (cu/daemon-running? pidfile))
+    :not-running
+    (do
+      (c/su
+       (cu/stop-daemon! pidfile))
+      :stopped)))
 
 (defn members
   "Fetch the cluster members from a random node (who will ask the leader)."
@@ -269,21 +274,23 @@
           everything))
 
       db/Process
-      (start! [_ test node]
+      (start! [_db test node]
         (start! test node))
 
-      (kill! [_ test node]
+      (kill! [_db test node]
         (kill! test node))
 
       db/Pause
       (pause!
-        [_db _test _node]
+        [_db _test node]
+        (info "Pausing" bin "on" node)
         (c/su
          (cu/grepkill! :stop bin))
         :paused)
 
       (resume!
-        [_db _test _node]
+        [_db _test node]
+        (info "Resuming" bin "on" node)
         (c/su
          (cu/grepkill! :cont bin))
         :resumed)


### PR DESCRIPTION
- Upgrade to the latest version of Jepsen
  (Will add new nemesis, features, etc after scheduled test runs confirm existing tests with new Jepsen continue to pass.)

- Enable generating docs

- Create a Test Summary Artifact:
  - make it fast and easy to view Jepsen results and latency plots
  - both passed and failed tests
  - currently:
    -  no artifacts for passing tests
   - failed test artifact is too large for a quick click & check interaction

- Common Clojure `.gitignore`
