### PR TITLE
Tune list-append test, and uniform handling of workloads

### DIFF
--- a/src/jepsen/dqlite/append.clj
+++ b/src/jepsen/dqlite/append.clj
@@ -1,7 +1,6 @@
 (ns jepsen.dqlite.append
   "Test for transactional list append."
-  (:require [clojure [string :as str]]
-            [jepsen [client :as client]]
+  (:require [jepsen [client :as client]]
             [jepsen.tests.cycle.append :as append]
             [jepsen.dqlite [client :as c]]))
 
@@ -27,9 +26,11 @@
 
 (defn workload
   "A list append workload."
-  [opts]
-  (assoc (append/test {:key-count         10
-                       :max-txn-length    2
+  [{:keys [key-count min-txn-length max-txn-length max-writes-per-key] :as _opts}]
+  (merge (append/test {:key-count          (or key-count 12)
+                       :min-txn-length     (or min-txn-length 1)
+                       :max-txn-length     (or max-txn-length 4)
+                       :max-writes-per-key (or max-writes-per-key 128)
                        :consistency-models [:serializable
                                             :strict-serializable]})
-         :client (Client. nil)))
+         {:client (Client. nil)}))

--- a/src/jepsen/dqlite/bank.clj
+++ b/src/jepsen/dqlite/bank.clj
@@ -41,6 +41,7 @@
   "A bank workload."
   [_opts]
   (merge (bank/test {:negative-balances? true})
+         options
          {:client (Client. nil)
           :final-generator (gen/phases
                             (gen/log "Final reads...")


### PR DESCRIPTION
This PR tunes the list-append test opts:

```clj
{:key-count           12 ;; prev 10
 :min-txn-length       1 ;; same
 :max-txn-length       4 ;; prev 2
 :max-writes-per-key 128 ;; prev 32
 }
```

Increasing the number of active keys, operations per transaction, and the active lifetime of a key will:
- drive dqlite with a more complex workload
- provide Jepsen a richer log file to analyze for consistency
- increase confidence in the results

The new values are consistent with the latest Jepsen RedisRaft and MongoDB tests.

----

Handle workloads consistently when building test map.
By convention:
```clj
(merge tests/noop-test
       cli-ops
       workload-results
       {:test-and-business :logic-config})
```
