### PR TITLE
More testable workflow: make callable, better artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: ${{ inputs.jepsenDqliteRepo || github.repository }}
-        ref: ${{ inputs.jepsenDqliteBranch || github.ref_name }}
+        ref: ${{ inputs.jepsenDqliteBranch || github.ref }}
 
     - name: Cache Go modules
       uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,20 +9,48 @@ on:
     inputs:
       raftRepo:
         description: 'Raft Repo'
-        required: true
         default: 'https://github.com/Canonical/raft.git'
       raftBranch:
         description: 'Raft Branch'
-        required: true
         default: 'master'
       dqliteRepo:
         description: 'Dqlite Repo'
-        required: true
         default: 'https://github.com/Canonical/dqlite.git'
       dqliteBranch:
         description: 'Dqlite Branch'
-        required: true
         default: 'master'
+  workflow_call:
+    inputs:
+      jepsenDqliteRepo:
+        type: string
+        required: false
+      jepsenDqliteBranch:
+        type: string
+        required: false
+      jepsenRepo:
+        type: string
+        required: false
+      jepsenBranch:
+        type: string
+        required: false
+      raftRepo:
+        type: string
+        required: false
+      raftBranch:
+        type: string
+        required: false
+      dqliteRepo:
+        type: string
+        required: false
+      dqliteBranch:
+        type: string
+        required: false
+
+env:
+  RAFT_REPO:   'https://github.com/Canonical/raft.git'
+  RAFT_BRANCH: 'master'
+  DQLITE_REPO:   'https://github.com/Canonical/dqlite.git'
+  DQLITE_BRANCH: 'master'
 
 jobs:
   test:
@@ -47,6 +75,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
+      with:
+        repository: ${{ inputs.jepsenDqliteRepo || github.repository }}
+        ref: ${{ inputs.jepsenDqliteBranch || github.ref_name }}
 
     - name: Cache Go modules
       uses: actions/cache@v3
@@ -76,6 +107,15 @@ jobs:
         sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libjna-java graphviz leiningen build-essential
         printf core | sudo tee /proc/sys/kernel/core_pattern
 
+    - name: Install local Jepsen
+      if: ${{ inputs.jepsenRepo && inputs.jepsenBranch }}
+      run: |
+        git clone --branch ${{ inputs.jepsenBranch }} --depth 1 ${{ inputs.jepsenRepo }}
+        cd jepsen/jepsen
+        git log -n 1
+        lein install
+        cd ../..
+
     - name: Install libbacktrace
       run: |
         git clone https://github.com/ianlancetaylor/libbacktrace --depth 1
@@ -88,9 +128,6 @@ jobs:
         cd ..
 
     - name: Build raft
-      env:
-        RAFT_REPO: 'https://github.com/Canonical/raft.git'
-        RAFT_BRANCH: 'master'
       run: |
           git clone --branch ${{ inputs.raftBranch || env.RAFT_BRANCH }} --depth 1 ${{ inputs.raftRepo || env.RAFT_REPO }}
           cd raft
@@ -102,9 +139,6 @@ jobs:
           cd ..
 
     - name: Build dqlite
-      env:
-        DQLITE_REPO: 'https://github.com/Canonical/dqlite.git'
-        DQLITE_BRANCH: 'master'
       run: |
           git clone --branch ${{ inputs.dqliteBranch || env.DQLITE_BRANCH }} --depth 1 ${{ inputs.dqliteRepo || env.DQLITE_REPO }}
           cd dqlite
@@ -126,14 +160,35 @@ jobs:
         go get -tags libsqlite3 github.com/canonical/go-dqlite/app
         go build -tags libsqlite3 -o resources/app resources/app.go
         sudo ufw disable
+        sleep 0.200
         sudo systemctl stop ufw.service
         sudo ./resources/network.sh setup 5
         if test ${{ matrix.workload }} = set && test ${{ matrix.nemesis }} = stop; then echo 120 >time-limit; else echo 240 >time-limit; fi
         lein run test --no-ssh --binary $(pwd)/resources/app --workload ${{ matrix.workload }} --time-limit $(cat time-limit) --nemesis ${{ matrix.nemesis }} --rate 100
         sudo ./resources/network.sh teardown 5
 
-    - uses: actions/upload-artifact@v3
-      if: failure()
+    - name: Jepsen log Summary
+      if: ${{ always() }}
+      run: tail -n 100 store/current/jepsen.log > tail-jepsen.log
+
+    - name: Summary Artifact
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
       with:
-        name: jepsen-data-${{ matrix.workload }}-${{ matrix.nemesis }}
-        path: store/dqlite*
+        name: jepsen-data-${{ matrix.workload }}-${{ matrix.nemesis }}-summary
+        path: |
+          tail-jepsen.log
+          store/dqlite*/**/results.edn
+          store/dqlite*/**/latency-raw.png
+          !**/current/
+          !**/latest/
+
+    - name: Failure Artifact
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: jepsen-data-${{ matrix.workload }}-${{ matrix.nemesis }}-failure
+        path: |
+          store/dqlite*
+          !**/current/
+          !**/latest/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ pom.xml.asc
 .hg/
 store/
 resources/app
+.calva/
+.clj-kondo/
+.lsp/

--- a/project.clj
+++ b/project.clj
@@ -12,4 +12,9 @@
              ;"-XX:+PrintGCDetails"
              ;"-verbose:gc"
              ]
-  :repl-options {:init-ns jepsen.dqlite})
+  :repl-options {:init-ns jepsen.dqlite}
+  :plugins [[lein-codox "0.10.8"]
+            [lein-localrepo "0.5.4"]]
+  :codox {:output-path "target/doc/"
+          :source-uri "../../{filepath}#L{line}"
+          :metadata {:doc/format :markdown}})


### PR DESCRIPTION
- Make the workflow callable from other workflows:

  - other repositories can call the workflow `with:` different `inputs:` for testing
  - specify a branch upgraded to the latest Jepsen
  - locally install/build an arbitrary Jepsen
  - same with raft/dqlite

- Better artifacts

  - Summary for quick click and scan of results, latency plot, tail of log
  - Avoid duplicate files, symlinks, in failure artifact 

- Try and fix occasional test failures cased by a race between the `ufw` calls, `sleep 0.200`

- Enable building docs

- Common Clojure `.gitignore`

----
 
I think this is the smallest YAML possible.
GitHub doesn't support:
- YAML anchors/aliases, &/*, for repeated text
- `env.` values in the `inputs:` context

So some repetition.

----

A workflow that shadows jepsen.dqlite tests but with latest Jepsen:

```yml
name: Test dqlite.jepsen tests

on:
  schedule:
    - cron: "0 */1 * * *"

jobs:
  call-jepsen-dqlite:
    uses: canonical/jepsen.dqlite/.github/workflows/test.yml@master
    with:
      jepsenDqliteRepo: nurturenature/jepsen.dqlite
      jepsenDqliteBranch: on-workflow_call-jepsen-0.3.2-SNAPSHOT
```