### PR TITLE
Enable process pause nemesis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,11 +65,13 @@ jobs:
           - partition
           - kill
           - stop
+          - pause
           - disk
           - member
           - partition,kill,stop
           - partition,kill,disk
           - partition,kill,member
+          - partition,pause,disk
     runs-on: ubuntu-20.04
     timeout-minutes: 25
     steps:
@@ -169,7 +171,7 @@ jobs:
 
     - name: Jepsen log Summary
       if: ${{ always() }}
-      run: tail -n 100 store/current/jepsen.log > tail-jepsen.log
+      run: tail -n 100 store/current/jepsen.log > store/current/tail-jepsen.log
 
     - name: Summary Artifact
       if: ${{ always() }}
@@ -177,9 +179,9 @@ jobs:
       with:
         name: jepsen-data-${{ matrix.workload }}-${{ matrix.nemesis }}-summary
         path: |
-          tail-jepsen.log
           store/dqlite*/**/results.edn
           store/dqlite*/**/latency-raw.png
+          store/dqlite*/**/tail-jepsen.log
           !**/current/
           !**/latest/
 

--- a/src/jepsen/dqlite/db.clj
+++ b/src/jepsen/dqlite/db.clj
@@ -248,6 +248,7 @@
         (kill! test node)
         (when tmpfs
           (db/teardown! tmpfs test node))
+        (Thread/sleep 200) ; avoid race: rm: cannot remove '/opt/dqlite/data': Directory not empty
         (c/su (c/exec :rm :-rf dir)))
 
       db/LogFiles

--- a/src/jepsen/dqlite/db.clj
+++ b/src/jepsen/dqlite/db.clj
@@ -276,8 +276,17 @@
         (kill! test node))
 
       db/Pause
-      (pause!  [_ test node] (c/su (cu/grepkill! :stop "app")))
-      (resume! [_ test node] (c/su (cu/grepkill! :cont "app")))
+      (pause!
+        [_db _test _node]
+        (c/su
+         (cu/grepkill! :stop bin))
+        :paused)
+
+      (resume!
+        [_db _test _node]
+        (c/su
+         (cu/grepkill! :cont bin))
+        :resumed)
 
       db/Primary
       (setup-primary! [db test node])


### PR DESCRIPTION
- Enable process pause nemesis:

  - clean up `pause!/resume!`functions
  - add to test workflow `matrix:`

- Will regularly exhibit canonical/raft#355

  - testing was done with Jepsen 0.3.2 and 0.2.6 is expected to be ==

- Misc

  - `sleep` to avoid `unmount/rm` race in tearing down database env
  - better success artifact 