### PR TITLE
More closely align existing disk nemesis with `jepsen.nemesis.combined`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,9 +69,10 @@ jobs:
           - disk
           - member
           - partition,kill,stop
-          - partition,kill,disk
+          - partition,kill
           - partition,kill,member
-          - partition,pause,disk
+          - partition,disk
+          - pause,disk
     runs-on: ubuntu-20.04
     timeout-minutes: 25
     steps:

--- a/src/jepsen/dqlite.clj
+++ b/src/jepsen/dqlite.clj
@@ -80,7 +80,8 @@
                        :pause     {:targets [nil :one :primaries :majority :all]}
                        :kill      {:targets [nil :one :primaries :majority :all]}
                        :interval  (:nemesis-interval opts)
-                       :disk      {:dir     db/data-dir
+                       :disk      {:targets [nil :one :majority :all] ; :primaries not supported
+                                   :dir     db/data-dir
                                    :size-mb 100}}
         local         (:dummy? (:ssh opts))
         os            (if local container/os ubuntu/os)

--- a/src/jepsen/dqlite/tmpfs.clj
+++ b/src/jepsen/dqlite/tmpfs.clj
@@ -6,7 +6,8 @@
                     [db :as db]
                     [generator :as gen]
                     [nemesis :as nem]
-                    [util :as util :refer [meh random-nonempty-subset]]]
+                    [util :as util :refer [meh]]]
+            [jepsen.nemesis.combined :as nc]
             [slingshot.slingshot :refer [try+ throw+]]))
 
 (defrecord DB [dir size-mb]
@@ -43,58 +44,60 @@
 
 (defrecord Nemesis [db]
   nem/Nemesis
-  (setup! [this test] this)
+  (setup! [this _test] this)
 
-  (invoke! [this test op]
+  (invoke! [_this test op]
     (assoc op :value
            (case (:f op)
-             :fill-disk (c/on-nodes test (random-nonempty-subset (:nodes test))
-                                    (fn [_ _] (fill! db)))
-             :free-disk  (c/on-nodes test
-                                     (fn [_ _] (free! db))))))
+             :fill-disk (let [targets (nc/db-nodes test db (:value op))]
+                          (c/on-nodes test targets
+                                      (fn [_ _] (fill! db))))
+             :free-disk (c/on-nodes test
+                                    (fn [_ _] (free! db))))))
 
-  (teardown! [this test])
+  (teardown! [_this _test])
 
   nem/Reflection
-  (fs [this]
+  (fs [_this]
     #{:fill-disk :free-disk}))
-
-(defn generator
-  "Generates a random mixture of fill-disk and free-disk operations."
-  [opts]
-  (let [stop (fn [test _] {:type  :info
-                           :f     :free-disk})
-        start (fn [test _] {:type :info
-                            :f    :fill-disk})]
-    (->> (gen/mix [start stop])
-         (gen/stagger (:interval opts)))))
 
 (defn package
   "Options:
+   ```clj
+   :faults #{:disk}
+   :disk {:targets [nil :one :primaries :majority :all]
+          :dir     db/data-dir
+          :size-mb 100}
+   ```
 
-    :faults  A set of faults we expect to generate. Should include :disk
-    :disk    Options specifically for disk failures
-
-  Disk options are:
-
-    :dir      The directory we'd like to turn into a tmpfs and fill
-    :size-mb  The size, in megabytes, of that directory
-
-  If faults includes disk, constructs a map with a DB, nemesis, generator, and
-  perf descriptor suitable for testing tmpfs."
-  [opts]
-  (assert (set? (:faults opts)))
-  (when ((:faults opts) :disk)
-    (let [disk-opts (:disk opts)
-          dir       (:dir disk-opts)
-          size-mb   (:size-mb disk-opts)
-          _         (assert (string? dir))
-          _         (assert (pos? size-mb))
-          db        (DB. (:dir disk-opts) (:size-mb disk-opts))]
+   Returns:
+   ```clj
+   {:db              ; tmpfs
+    :nemesis         ; disk nemesis for tmpfs
+    :generator       ; fill/free disk
+    :final-generator ; free disk
+    :perf            ; pretty plots            
+   ```"
+  [{:keys [faults disk interval] :as _opts}]
+  (when (:disk faults)
+    (let [{:keys [targets dir size-mb]} disk
+          _  (assert (string? dir))
+          _  (assert (pos? size-mb))
+          db (DB. dir size-mb)
+          fills (fn [_ _]
+                   {:type  :info
+                    :f     :fill-disk
+                    :value (rand-nth targets)})
+          frees (repeat
+                  {:type  :info
+                   :f     :free-disk
+                   :value :all})
+          interval (or interval nc/default-interval)]
       {:db              db
        :nemesis         (Nemesis. db)
-       :generator       (generator opts)
-       :final-generator {:type :info, :f :free-disk, :value nil}
+       :generator       (->> (gen/flip-flop fills frees)
+                             (gen/stagger interval))
+       :final-generator (gen/once frees)
        :perf            #{{:name  "disk"
                            :start #{:fill-disk}
                            :stop  #{:free-disk}


### PR DESCRIPTION
Bring the existing disk nemesis into closer alignment with `jepsen.nemesis.combined`.

- Configure `:targets` in nemeses opts:
  ```clj
  :disk {:targets [nil :one :majority :all] ; :primaries not supported
         :dir     db/data-dir
         :size-mb 100}
  ```


- Update generator:
  - from random mix of fills and frees
    ```clj
    (gen/mix [fill free])
    ```
  - to flip-flopping between filled and freed
    ```clj
    (gen/flip-flop fills frees)
    ``` 


- Update test matrix:
  - a bit more diversity
  - temporary config, will rationalize matrix once all nemeses updated


- Net effects:
  - equivalent coverage
  - slightly better behaved
    - random mix can repeatedly fill leading to an uninteresting test,
      e.g. a data center without storage for the duration of the test
  - slightly more efficient
    - random mix can fill a full disk, free a freed disk,
      vs flip-flopping between states


In pre PR testing with Jepsen 0.3.2, the disk nemesis had a slightly increased chance of triggering assertions mentioned in previous raft issues.
Expecting this to also be true with Jepsen 0.2.6.

