### PR TITLE
Clarify stop/kill, align stop nemesis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,9 +68,9 @@ jobs:
           - pause
           - disk
           - member
-          - partition,kill,stop
+          - partition,stop
           - partition,kill
-          - partition,kill,member
+          - partition,member
           - partition,disk
           - pause,disk
     runs-on: ubuntu-20.04

--- a/src/jepsen/dqlite.clj
+++ b/src/jepsen/dqlite.clj
@@ -78,6 +78,7 @@
                        :nodes  (:nodes opts)
                        :partition {:targets (:partition-targets opts)}
                        :pause     {:targets [nil :one :primaries :majority :all]}
+                       :stop      {:targets [nil :one :primaries :majority :all]}
                        :kill      {:targets [nil :one :primaries :majority :all]}
                        :interval  (:nemesis-interval opts)
                        :disk      {:targets [nil :one :primaries :majority :all]


### PR DESCRIPTION
Several years ago, Jepsen changed its stop semantics/implementation to kill in its `db` protocol.
Also, no standard nemesis package for stop was provided.

The dqlite tests adapted by [switching the semantics](https://github.com/canonical/jepsen.dqlite/commit/1435e8402e12b0af7890ea22bc1cf56512f21333#diff-db60539166d75844fd5fb39c523a331b188d9b2d0c042782220a0973caed6979) and implementation of stop/kill, making stop = kill, kill = stop, and some followup workarounds to handle the app pid file.

This PR defines stop and kill as stop and kill, and aligns the stop nemesis with `jepsen.nemesis.combined`.  

- `start!`
  - guarded with `cu/daemon-running?`
  - removed pid file workaround

- `kill!`
  - now a real kill -9

- `stop!`
  - guarded with `cu/daemon-running?`
  - removed pid file workaround

- Stop nemesis/package:
  - configured with standard targeting opts in nemesis-opts
    ```clj
    {:stop {:targets [nil :one :primaries :majority :all]}}
    ```
  - uses `(gen/flip-flop stops starts)` vs `(gen/mix [stop stop start])`

- Better logging
  - `:already-running`, `:not-running`, `:stopped`, `:killed`

- Test `matrix.` lightly modified for:
  - stop/kill name change
  - behavior
  - fuller matrix for all nemeses to be addressed in future PR

- Misc
  - nicer looking nemesis plotting of stable/health

----

Net effects:
- stop:
  - more complete coverage vs favoring a minority
  - more effective, flip flopping between stop/start vs possibly stopping a stopped, starting a running node
- kill, will -9 have an impact?
