### PR TITLE
Update Jepsen to 0.3.2-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [jepsen "0.2.6"]
+                 [jepsen "0.3.2-SNAPSHOT"]
                  [clj-http "3.10.1"]]
   :main jepsen.dqlite
   :jvm-opts ["-Djava.awt.headless=true"


### PR DESCRIPTION
This PR is a followup of #87 that updates Jepsen to the latest version.

In the original PR, @MathieuBordere asked to [test the tests](https://github.com/canonical/jepsen.dqlite/pull/87#issuecomment-1467755261).

Since that time, a shadow repository has been running the tests with a branch updated to Jepsen 0.3.2-SNAPSHOT:
```yaml
name: Test dqlite.jepsen

on:
  schedule:
    - cron: "0/30 * * * *"

jobs:
  call-jepsen-dqlite:
    uses: nurturenature/jepsen.dqlite/.github/workflows/test.yml@latest-jepsen
    with:
      jepsenDqliteRepo: nurturenature/jepsen.dqlite
      jepsenDqliteBranch: latest-jepsen
```

and the test [pass/fail results](https://github.com/nurturenature/jepsen.dqlite-test/actions) have been comparable.
