### PR TITLE
Enable packet nemesis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,7 @@ jobs:
           - partition,kill
           - partition,member
           - partition,disk
+          - packet,stop
           - pause,disk
     runs-on: ubuntu-20.04
     timeout-minutes: 25

--- a/src/jepsen/dqlite/nemesis.clj
+++ b/src/jepsen/dqlite/nemesis.clj
@@ -126,6 +126,7 @@
   (let [opts (update opts :faults set)]
     (->> (concat [(nc/partition-package opts)
                   (nc/db-package opts)
+                  (nc/packet-package opts)
                   (member-package opts)
                   (stop-package opts)
                   (stable-package opts)]


### PR DESCRIPTION
This PR enables the packet nemesis.
As discussed in #66, delay may be of interest.
Other faults will (mostly?) translate into delay as faults are expected to be handled by the stack.

The packet nemesis is configured with two faults, delay and corruption + reordering. Note reordering requires some delay.

```clj
{:packet {:targets   (:node-targets opts)
          :behaviors [{:delay {:time :70ms :jitter :10ms}}
                      {:corrupt {:percent :33%} :reorder {:percent :33%} :delay {:time :25ms :jitter :5ms}}]}}
```

The initial values were chosen by increasing the severity of the `:behaviors` until leadership changes were observed.

```clj
jepsen.dqlite.db: Primary cache now #{n4}
...
:nemesis :start-packet [:primaries {:delay {:time :70ms, :jitter :10ms}}]
:nemesis :start-packet [:shaped {"n1" #{"n4"}, "n2" #{"n4"}, "n3" #{"n4"}, "n4" #{"n2" "n5" "n1" "n3"}, "n5" #{"n4"}} :netem [:delay :70ms :10ms :25% :distribution :normal]]
...
jepsen.dqlite.db: Primary cache now #{n4 n3}
jepsen.dqlite.db: Primary cache now #{n3}
...
:nemesis :stop-packet nil
:nemesis :stop-packet [:reliable {"n1" nil, "n2" nil, "n3" nil, "n4" nil, "n5" nil}]
```

A single entry, `packet,stop`, was added to the test matrix.

Will revisit `:behaviors` config and the test matrix after it's been running for a bit.

----

Misc

- `all-nemeses` CLI handling cleaned up

----

Sample testing run with `--workload bank --nemesis packet --node-targets primaries`:

![--workload bank --nemesis packet --node-targets primaries](https://user-images.githubusercontent.com/86082495/228971078-2e573d56-3dae-408a-b349-a6172f524765.png)
