### PR TITLE
pin Jepsen 0.3.2, all set workloads time-limit 180

### DIFF
--- a/.github/workflows/test-build-run.yml
+++ b/.github/workflows/test-build-run.yml
@@ -168,7 +168,7 @@ jobs:
         sleep 0.200
         sudo systemctl stop ufw.service
         sudo ./resources/network.sh setup 5
-        if test ${{ matrix.workload }} = set && test ${{ matrix.nemesis }} = none; then echo 180 >time-limit; else echo 240 >time-limit; fi
+        if test ${{ matrix.workload }} = set; then echo 180 >time-limit; else echo 240 >time-limit; fi
         lein run test --no-ssh --binary $(pwd)/resources/app \
           --workload ${{ matrix.workload }} \
           --nemesis ${{ matrix.nemesis }} \

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.11.1"]
-                 [jepsen "0.3.2-SNAPSHOT"]
+                 [jepsen "0.3.2"]
                  [clj-http "3.10.1"]]
   :main jepsen.dqlite
   :jvm-opts ["-Djava.awt.headless=true"


### PR DESCRIPTION
- Jepsen released 0.3.2 today so it can be pinned vs using 0.3.2-SNAPSHOT.

- make all set workloads time-limit 180
  - when set workloads do a lot of transactions, e.g. no nemesis, or occasionally with some nemesis, the set gets quite large
  - tests fail with Java OOM in expected to pass
  - avoid false positives