### PR TITLE
ci: enable disk-mode tests

### DIFF
--- a/.github/workflows/test-build-run.yml
+++ b/.github/workflows/test-build-run.yml
@@ -75,6 +75,7 @@ jobs:
       matrix:
         workload: ${{ fromJSON(inputs.workloads) }}
         nemesis: ${{ fromJSON(inputs.nemeses) }}
+        disk: [0, 1]
     runs-on: ubuntu-20.04
     timeout-minutes: 25
     steps:
@@ -174,6 +175,7 @@ jobs:
           --nemesis ${{ matrix.nemesis }} \
           --rate 100 \
           --time-limit $(cat time-limit) \
+          --disk ${{ matrix.disk }} \
           ${{ inputs.cli-opts }}
         sudo ./resources/network.sh teardown 5
 

--- a/resources/app.go
+++ b/resources/app.go
@@ -587,6 +587,7 @@ func main() {
 	node := flag.String("node", "", "node name")
 	cluster := flag.String("cluster", "", "names of all nodes in the cluster")
 	latency := flag.Int("latency", 5, "average one-way network latency, in msecs")
+	disk := flag.Int("disk", 0, "non-0 value enables disk-mode")
 
 	flag.Parse()
 
@@ -619,6 +620,7 @@ func main() {
 		app.WithNetworkLatency(time.Duration(*latency) * time.Millisecond),
 		app.WithRolesAdjustmentFrequency(time.Second),
 		app.WithSnapshotParams(dqlite.SnapshotParams{Threshold: 128, Trailing: 1024}),
+		app.WithDiskMode(*disk != 0),
 	}
 
 	// When rejoining set app.WithCluster() to the full list of existing

--- a/src/jepsen/dqlite.clj
+++ b/src/jepsen/dqlite.clj
@@ -195,6 +195,10 @@
     :parse-fn parse-long
     :validate [pos? "Must be a positive number."]]
 
+   [nil "--disk INT" "Disk mode on or off. Non-0 value to turn on."
+    :default 0
+    :parse-fn parse-long]
+
    ["-r" "--rate HZ" "Approximate request rate, in hz"
     :default 10
     :parse-fn parse-long

--- a/src/jepsen/dqlite/db.clj
+++ b/src/jepsen/dqlite/db.clj
@@ -68,6 +68,7 @@
                          :chdir   data-dir}
                         binary
                         :-dir data-dir
+                        :-disk (:disk test)
                         :-node (name node)
                         :-latency (:latency test)
                         :-cluster (str/join "," (:nodes test))))))


### PR DESCRIPTION
Runs the jepsen suite with the disk-based VFS. 

Piping a number through `github actions -> jepsen -> go`  was a bit more obvious for me to do than a boolean, that's why it's an int flag :-)

also, `test.yml` and `test-fail.yml` try to source `test-build-run.yml` from the canonical master branch, I've adapted that file in this PR, those changes are not being picked up by this test run as the master file has not been adapted, but it will work after merging ... (tested on own repo).