### PR TITLE
workflows: Move disk tests to expect fail.

### DIFF
--- a/.github/workflows/test-build-run.yml
+++ b/.github/workflows/test-build-run.yml
@@ -21,6 +21,9 @@ on:
       nemeses:
         description: "Jepsen nemesis as JSON, e.g. [ 'pause,disk' ]"
         required: true
+      disk:
+        description: "Enable or disable dqlite's disk-mode e.g. [ '0', '1' ]"
+        required: true
       cli-opts:
         description: 'Jepsen cli opts, e.g. --node-targets primaries'
         required: false
@@ -58,6 +61,9 @@ on:
       nemeses:
         type: string
         required: true
+      disk:
+        type: string
+        required: true
       cli-opts:
         type: string
         required: false
@@ -75,7 +81,7 @@ jobs:
       matrix:
         workload: ${{ fromJSON(inputs.workloads) }}
         nemesis: ${{ fromJSON(inputs.nemeses) }}
-        disk: [0, 1]
+        disk: ${{ fromJSON(inputs.disk) }}
     runs-on: ubuntu-20.04
     timeout-minutes: 25
     steps:

--- a/.github/workflows/test-custom.yml
+++ b/.github/workflows/test-custom.yml
@@ -21,6 +21,9 @@ on:
       nemeses:
         description: Nemeses as a JSON array, e.g. [ 'pause', 'disk' ]
         required: true
+      disk:
+        description: "Enable or disable dqlite's disk-mode e.g. [ '0', '1 ]"
+        required: true
       cli-opts:
         description: Jepsen cli opts, e.g. --node-targets primaries
         required: false
@@ -31,6 +34,7 @@ jobs:
     with:
       workloads: ${{ inputs.workloads }}
       nemeses: ${{ inputs.nemeses }}
+      disk: ${{ inputs.disk }}
       cli-opts: ${{ inputs.cli-opts }}
       jepsen-dqlite-repo: canonical/jepsen.dqlite
       jepsen-dqlite-branch: master

--- a/.github/workflows/test-fail.yml
+++ b/.github/workflows/test-fail.yml
@@ -27,6 +27,8 @@ jobs:
       nemeses: >
         [ 'partition,disk',
           'pause', 'pause,disk' ]
+      disk: >
+        [ '1' ]
       jepsen-dqlite-repo: ${{ github.repository }}
       jepsen-dqlite-branch: ${{ github.ref }}
       raft-repo: ${{ inputs.raft-repo || 'https://github.com/Canonical/raft.git' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
         [ 'none', 'partition', 'kill', 'stop', 'disk', 'member',
           'partition,stop', 'partition,kill', 'partition,member',
           'packet,stop' ]
+      disk: >
+        [ '0' ]
       jepsen-dqlite-repo: ${{ github.repository }}
       jepsen-dqlite-branch: ${{ github.ref }}
       raft-repo: ${{ inputs.raft-repo || 'https://github.com/Canonical/raft.git' }}


### PR DESCRIPTION
Move the disk tests to the expect fail suite as there are a couple of them that consistently fail.