### PR TITLE
test-fail: remove `append` workload and `pause` nemesis.

### DIFF
--- a/.github/workflows/test-fail.yml
+++ b/.github/workflows/test-fail.yml
@@ -23,10 +23,10 @@ jobs:
     uses: canonical/jepsen.dqlite/.github/workflows/test-build-run.yml@master
     with:
       workloads: >
-        [ 'append', 'bank', 'set' ]
+        [ 'bank', 'set' ]
       nemeses: >
         [ 'partition,disk',
-          'pause', 'pause,disk' ]
+          'pause,disk' ]
       disk: >
         [ '1' ]
       jepsen-dqlite-repo: ${{ github.repository }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       nemeses: >
         [ 'none', 'partition', 'kill', 'stop', 'disk', 'member',
           'partition,stop', 'partition,kill', 'partition,member',
-          'packet,stop' ]
+          'packet,stop', 'pause' ]
       disk: >
         [ '0' ]
       jepsen-dqlite-repo: ${{ github.repository }}


### PR DESCRIPTION
Seems to have passed consistently.