### PR TITLE
Temporarily reduce frequency of scheduled runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '0 */1 * * *'
+    - cron: '@daily'
   workflow_dispatch:
     inputs:
       raft-repo:


### PR DESCRIPTION
We have tracking issues for the known bugs that are regularly turned up at this point, so the hourly failures aren't giving us new information. We can increase the frequency again once (some of) those bugs are fixed.

Signed-off-by: Cole Miller <cole.miller@canonical.com>