### PR TITLE
Address the empty tarball issue

### DIFF
--- a/src/jepsen/dqlite/db.clj
+++ b/src/jepsen/dqlite/db.clj
@@ -271,8 +271,8 @@
               app-binary (when (seq core-dumps) binary)
               everything (remove nil? [logfile tarball app-binary])]
           (try
-            (c/exec :tar :cjf tarball data-dir)
-            (catch Exception e (str "caught exception: " (.getMessage e))))
+            (c/exec :sudo :tar :cjf tarball data-dir)
+            (catch Exception e (info "caught exception: " (.getMessage e))))
           everything))
 
       db/Process


### PR DESCRIPTION
Closes #105. The basic issue is that the `tar` process was getting SIGPERM while trying to read the data directory -- this is fixed by invoking with sudo. The failure was masked by a use of `str` instead of `info` or another function that prints to the log.

With this change, I sometimes see tar complaining about the data directory changing during archival, because the app process is still running while Jepsen runs `log-files`. I'm not sure how to deal with that, because we don't control the order of events during shutdown, but I think it can be left to a follow-up PR in any case.

Signed-off-by: Cole Miller <cole.miller@canonical.com>