### PR TITLE
Speed up the Jepsen job a bit

### DIFF
--- a/.github/workflows/test-build-run.yml
+++ b/.github/workflows/test-build-run.yml
@@ -130,7 +130,7 @@ jobs:
       timeout-minutes: 15
       run: |
         sudo apt update
-        sudo apt install -y gnuplot libsqlite3-dev libuv1-dev liblz4-dev libjna-java graphviz leiningen build-essential
+        sudo apt install -y gnuplot-nox libsqlite3-dev libuv1-dev liblz4-dev libjna-java graphviz leiningen build-essential
         printf core | sudo tee /proc/sys/kernel/core_pattern
 
     - name: Install local Jepsen
@@ -151,7 +151,6 @@ jobs:
         make -j4
         sudo make install
         sudo ldconfig
-        cd ..
 
     - name: Check out raft
       uses: actions/checkout@v3
@@ -162,12 +161,15 @@ jobs:
 
     - name: Build raft
       run: |
+        shopt -s globstar
         cd raft
         git log -n 1
-        autoreconf -i
-        ./configure --enable-debug --enable-backtrace
-        make -j4
-        sudo make install
+        cc -pthread -g3 -shared -fPIC \
+          -D_GNU_SOURCE -DLZ4_AVAILABLE -DLZ4_ENABLED -DHAVE_LINUX_AIO_ABI_H -DRAFT_ASSERT_WITH_BACKTRACE \
+          -o libraft.so src/**/*.c -lbacktrace -luv -llz4
+        sudo install -m755 libraft.so /usr/local/lib
+        sudo install -m644 include/raft.h /usr/local/include
+        sudo install -m644 -D -t /usr/local/include/raft include/raft/*.h
         sudo ldconfig
 
     - name: Check out dqlite
@@ -179,12 +181,13 @@ jobs:
 
     - name: Build dqlite
       run: |
+        shopt -s globstar
         cd dqlite
         git log -n 1
         autoreconf -i
-        ./configure --enable-debug --enable-backtrace
-        make -j4
-        sudo make install
+        cc -pthread -g3 -shared -fPIC -D_GNU_SOURCE -DDQLITE_ASSERT_WITH_BACKTRACE -o libdqlite.so src/**/*.c -lbacktrace -luv -lsqlite3 -lraft
+        sudo install -m755 libdqlite.so /usr/local/lib
+        sudo install -m644 include/dqlite.h /usr/local/include
         sudo ldconfig
 
     - name: Test


### PR DESCRIPTION
- Bypass the build system (in particular the configure step) when building raft and dqlite
- Install gnuplot-nox instead of gnuplot, since we don't need a graphical frontend

I also spent some time experimenting with using a Docker image instead of installing a pile of dependencies in every job, but this comes with additional complications and the `docker pull` step takes a while on its own for the size of image we'd be dealing with, so didn't pursue it for this PR.

Signed-off-by: Cole Miller <cole.miller@canonical.com>