### PR TITLE
In kill!, wait for the dqlite process to exit before proceeding

### DIFF
--- a/.github/workflows/test-build-run.yml
+++ b/.github/workflows/test-build-run.yml
@@ -175,6 +175,10 @@ jobs:
         sudo sysctl -w kernel.core_pattern=core
         sudo sysctl -w fs.suid_dumpable=2
 
+    - name: install strace
+      run: |
+        sudo apt install -y strace
+
     - name: Test
       env:
         LD_LIBRARY_PATH: "/usr/local/lib"

--- a/src/jepsen/dqlite/db.clj
+++ b/src/jepsen/dqlite/db.clj
@@ -66,6 +66,8 @@
                          :logfile logfile
                          :pidfile pidfile
                          :chdir   data-dir}
+                        "/usr/bin/strace"
+                        :-e "signals"
                         binary
                         :-dir data-dir
                         :-disk (:disk test)

--- a/src/jepsen/dqlite/db.clj
+++ b/src/jepsen/dqlite/db.clj
@@ -86,6 +86,8 @@
              (c/exec :tail :-f (str "--pid=" pid) "/dev/null")))
          (catch [:type :jepsen.control/nonzero-exit, :exit 0] _
            nil)
+         (catch [:type :jepsen.control/nonzero-exit, :exit 1] _
+           nil)
          (catch [:type :jepsen.control/nonzero-exit, :exit 123] e
            (if (re-find #"No such process" (:err e))
              ; Ah, process already exited


### PR DESCRIPTION
Try to deal with the `rm -rf /opt/dqlite/data` ENOTEMPTY issue in a more principled way

Signed-off-by: Cole Miller <cole.miller@canonical.com>