### PR TITLE
Don't bother removing the dqlite directory at the end of a run

### DIFF
--- a/src/jepsen/dqlite/db.clj
+++ b/src/jepsen/dqlite/db.clj
@@ -254,9 +254,7 @@
           (future-cancel t))
         (kill! test node)
         (when tmpfs
-          (db/teardown! tmpfs test node))
-        (Thread/sleep 200) ; avoid race: rm: cannot remove '/opt/dqlite/data': Directory not empty
-        (c/su (c/exec :rm :-rf dir)))
+          (db/teardown! tmpfs test node)))
 
       db/LogFiles
       (log-files [_ test node]


### PR DESCRIPTION
There's not really any utility in trying to remove it, since each GHA run happens on a transient VM. Still want to fix #125 properly, but in the meantime this will cut down significantly on false-alarm failures in the scheduled runs.

Signed-off-by: Cole Miller <cole.miller@canonical.com>