### PR TITLE
dqlite: Don't trigger assertion pattern on non-error log.

### DIFF
--- a/src/jepsen/dqlite.clj
+++ b/src/jepsen/dqlite.clj
@@ -46,7 +46,7 @@
 
 (def assertion-pattern
   "An egrep pattern for finding assertion errors in log files."
-  "Assertion|raft_start|start-stop-daemon|for jepsen")
+  "Assertion|raft_start\\(\\)|start-stop-daemon|for jepsen")
 
 (defn core-dump-checker
   []


### PR DESCRIPTION
The new pattern allows to catch errors propagated from failing to start the raft node while not matching normal log lines.

example error that is still caught
>raft_start(): io: closed segment 0000xxxx-0000xxxx is past last snapshot-x-xxxx-xxxxxx

quick fix for #136 , should probably take a deeper look at it, but I want the jepsen tests to run.